### PR TITLE
Change the title bar style to `hidden` to fix #133

### DIFF
--- a/src/main/windows/window.ts
+++ b/src/main/windows/window.ts
@@ -141,7 +141,7 @@ class Window {
       icon: path.join ( __static, 'images', `icon.${is.windows () ? 'ico' : 'png'}` ),
       show: false,
       title: pkg.productName,
-      titleBarStyle: 'hiddenInset',
+      titleBarStyle: 'hidden',
       webPreferences: {
         webSecurity: false
       }


### PR DESCRIPTION
Change the title bar style to `hidden` to fix #133, caused by [electron#16418](https://github.com/electron/electron/issues/16418).  This solution was mentioned [here](https://github.com/electron/electron/issues/16418#issuecomment-456263303).