### PR TITLE
run KaTeX before showdown

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -43,7 +43,11 @@ const Config = {
   katex: {
     throwOnError: true,
     displayMode: false,
-    errorColor: '#f44336'
+    errorColor: '#f44336',
+    delimiters: [
+      { left: '$$', right: '$$', display: true },
+      { left: '$', right: '$', display: false },
+    ]
   },
   mermaid: { //URL: https://github.com/knsv/mermaid/blob/7d3578b31aeea3bc9bbc618dcda57d82574eaffb/src/mermaidAPI.js#L51
     gantt: {

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -45,8 +45,11 @@ const Config = {
     displayMode: false,
     errorColor: '#f44336',
     delimiters: [
-      { left: '$$', right: '$$', display: true },
-      { left: '$', right: '$', display: false },
+      { left: "$$", right: "$$", display: true }, // katex default
+      { left: "\\[", right: "\\]", display: true }, // katex default
+      { left: "\\(", right: "\\)", display: false }, // katex default
+      { left: '~', right: '~', display: false, asciimath: true },
+      { left: '&&', right: '&&', display: true, asciimath: true },
     ]
   },
   mermaid: { //URL: https://github.com/knsv/mermaid/blob/7d3578b31aeea3bc9bbc618dcda57d82574eaffb/src/mermaidAPI.js#L51

--- a/src/renderer/utils/markdown.ts
+++ b/src/renderer/utils/markdown.ts
@@ -494,20 +494,42 @@ const Markdown = {
 
     if ( !str || !Markdown.is ( str ) ) return `<p>${str}</p>`;
 
-    // render KaTeX in str
+    // render KaTeX/AsciiMath in str
     {
       let doc = '';
-      let data = [{type: "text", data: str, rawData: str, display: false}];
+      let data = [{type: "text", data: str, rawData: str, display: {display: false, ascii: false}}];
       const delimiters = Config.katex.delimiters || [];
-      for (let i = 0; i < delimiters.length; i++)
-        data = KatexSplit(data, delimiters[i].left, delimiters[i].right, delimiters[i].display || false);
+      for (let i = 0; i < delimiters.length; i++) {
+        // KatexSplit (= splitAtDelimiters) expects a boolean as 4th parameter,
+        // but only copies the argument into data[i].display, so we give it an
+        // object with { .display, .ascii } from the delimiter
+        const display = {
+          display: delimiters[i].display || false,
+          ascii: delimiters[i].asciimath || false
+        };
+
+        data = KatexSplit(data, delimiters[i].left, delimiters[i].right, display);
+      }
       for (let i = 0; i < data.length; i++) {
         if (data[i].type === "text") {
           doc += data[i].data;
         } else {
+          let math = data[i].data;
+
+          // convert AsciiMath to TeX if necessary
+          if(data[i].display.ascii) {
+            try {
+              math = AsciiMath.toTeX ( math );
+            } catch ( e ) {
+              console.error ( `[asciimath] ${e.message}` );
+              doc += data[i].rawData;
+              continue
+            }
+          }
+
           try {
-            Config.katex.displayMode = data[i].display;
-            doc += katex.renderToString ( data[i].data , Config.katex );
+            Config.katex.displayMode = data[i].display.display;
+            doc += katex.renderToString ( math , Config.katex );
           } catch ( e ) {
             console.error ( `[katex] ${e.message}` );
             doc += data[i].rawData;


### PR DESCRIPTION
This runs KaTeX on the raw `render` input string before it is passed to showdown. Since KaTeX produces HTML, which I believe showdown leaves completely alone, this should be transparent to all non-math output. It seems to get rid of almost all formatting problems, which are due to showdown escaping/normalisation interference (which cannot be fixed in an extension).

The format is what I perceive to be the most common and useful one where everything between single `$` is converted to inline math, and everything between `$$` is converted to display math, **ignoring newlines**. This means in particular that all KaTeX environments now work as expected.

I have left the ` ```katex` code blocks alone, to not break anyone's notes. Since this seems like it was a workaround, it might be desirable to take it out entirely.
