### PR TITLE
Add renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["config:base", ":rebaseStalePrs"]
+}


### PR DESCRIPTION
[Renovate](https://renovatebot.com/) is an automated dependency updater. This PR adds a barebones config for renovate. In order to enable renovate, you'll have to [Install the GitHub App](https://renovatebot.com/docs/install-github-app/) (It's free for open source projects).

After your merge this PR, and install the GitHub App, renovate will open a PR to convert your dependencies from ranges to pinned versions (See [this PR](https://github.com/JamieMagee/notable/pull/1) for an example). Pinned versions give you the benefit of having a reproducible build, and ranges aren't required when the pinned versions can be updated automatically. Renovate has a [great page about range vs pin](https://renovatebot.com/docs/dependency-pinning/).

Renovate is extremely flexible in it's configuration, and can allow automerging of minor version bumps, required reviewers for PRs, auto adding tags, etc. Check out the [configuration options](https://renovatebot.com/docs/configuration-options/) page for a complete overview, or let me know what sort of behaviour you expect from renovate, and I can adjust the config here.