### PR TITLE
Correct typos in tutorial

### DIFF
--- a/resources/tutorial/notes/03 - The Middlebar.md
+++ b/resources/tutorial/notes/03 - The Middlebar.md
@@ -11,9 +11,9 @@ The middlebar shows you all notes contained in the currently active category, pr
 
 To search just type something in the search bar.
 
-The title of notes is searched in _fuzzly_, which basically means that you can omit some characters from the query: if for instance there's a note titled "Notable" you can also find it by typing "Noab" or "Notae", as long as the characters are in the right order the note will be found.
+The title of notes is searched in _fuzzily_, which basically means that you can omit some characters from the query: if for instance there's a note titled "Notable" you can also find it by typing "Noab" or "Notae", as long as the characters are in the right order the note will be found.
 
-The content of notes is searched in too, but not fuzzly, a full-match is required in this case.
+The content of notes is searched in too, but not fuzzily, a full-match is required in this case.
 
 ## New Note Button
 


### PR DESCRIPTION
`fuzzly` changed to `fuzzily`.
(See https://en.oxforddictionaries.com/definition/fuzzily)