### PR TITLE
Enable scrolling past last line

### DIFF
--- a/src/renderer/utils/monaco.ts
+++ b/src/renderer/utils/monaco.ts
@@ -50,7 +50,7 @@ const Monaco = {
       verticalScrollbarSize: 12
     },
     scrollBeyondLastColumn: 0,
-    scrollBeyondLastLine: false,
+    scrollBeyondLastLine: true,
     snippetSuggestions: 'none',
     wordWrap: Settings.get ( 'monaco.editorOptions.wordWrap' ),
     wordWrapColumn: 1000000,


### PR DESCRIPTION
Closes #168 

I was going to add this as a feature request, saw that it was already requested and decided to look if it was easy with Monaco, and it is!

It's something I've wanted for a long time, specially when writing large files, all my new text stays on the bottom of the screen and it interrupts my workflow.

The current workaround is to add a lot of new lines at the end of the file.

I don't think there are any cons in lefting this as default.