### PR TITLE
:sparkles: render HTML within middlebar note title - #563

### DIFF
--- a/src/renderer/components/main/middlebar/note.tsx
+++ b/src/renderer/components/main/middlebar/note.tsx
@@ -15,7 +15,7 @@ const Note = ({ note, style, title, hasAttachments, isActive, isDeleted, isFavor
 
   return (
     <div style={style} className={`note ${!isMultiEditorEditing && isActive ? 'label' : 'button'} ${( isMultiEditorEditing ? isSelected : isActive ) ? 'active' : ''} list-item`} data-checksum={note.checksum} data-filepath={note.filePath} data-deleted={isDeleted} data-favorited={isFavorited} onClick={onClick}>
-      <span className="title small">{title}</span>
+      <span className="title small" dangerouslySetInnerHTML={{ __html: title }} />
       {!hasAttachments ? null : (
         <i className="icon xxsmall">paperclip</i>
       )}

--- a/src/renderer/components/main/middlebar/note.tsx
+++ b/src/renderer/components/main/middlebar/note.tsx
@@ -15,7 +15,7 @@ const Note = ({ note, style, title, hasAttachments, isActive, isDeleted, isFavor
 
   return (
     <div style={style} className={`note ${!isMultiEditorEditing && isActive ? 'label' : 'button'} ${( isMultiEditorEditing ? isSelected : isActive ) ? 'active' : ''} list-item`} data-checksum={note.checksum} data-filepath={note.filePath} data-deleted={isDeleted} data-favorited={isFavorited} onClick={onClick}>
-      <span className="title small" dangerouslySetInnerHTML={{ __html: title }} />
+      <span className="title small">{title}</span>
       {!hasAttachments ? null : (
         <i className="icon xxsmall">paperclip</i>
       )}

--- a/src/renderer/containers/main/note.ts
+++ b/src/renderer/containers/main/note.ts
@@ -6,6 +6,7 @@ import {shell} from 'electron';
 import Dialog from 'electron-dialog';
 import * as CRC32 from 'crc-32'; // Not a cryptographic hash function, but it's good enough (and fast!) for our purposes
 import * as fs from 'fs';
+import { AllHtmlEntities as entities } from 'html-entities';
 import {Container, autosuspend} from 'overstated';
 import * as path from 'path';
 import Config from '@common/config';
@@ -16,7 +17,6 @@ import Metadata from '@renderer/utils/metadata';
 import Path from '@renderer/utils/path';
 import Tags, {TagSpecials} from '@renderer/utils/tags';
 import Utils from '@renderer/utils/utils';
-import { AllHtmlEntities as entities } from 'html-entities';
 
 const {ALL, FAVORITES, TAGS, TEMPLATES, UNTAGGED, TRASH} = TagSpecials;
 

--- a/src/renderer/containers/main/note.ts
+++ b/src/renderer/containers/main/note.ts
@@ -16,6 +16,7 @@ import Metadata from '@renderer/utils/metadata';
 import Path from '@renderer/utils/path';
 import Tags, {TagSpecials} from '@renderer/utils/tags';
 import Utils from '@renderer/utils/utils';
+import { AllHtmlEntities as entities } from 'html-entities';
 
 const {ALL, FAVORITES, TAGS, TEMPLATES, UNTAGGED, TRASH} = TagSpecials;
 
@@ -295,7 +296,7 @@ class Note extends Container<NoteState, MainCTX> {
 
   getTitle = ( note: NoteObj | undefined = this.state.note ): string => {
 
-    return note ? note.metadata.title : '';
+    return note ? entities.decode(note.metadata.title) : '';
 
   }
 


### PR DESCRIPTION
Notes created with HTML entities in the title now render the HTML version instead of encoded entities.

Resolves #563 