### PR TITLE
Proper filename access for popover context menu

### DIFF
--- a/src/renderer/components/main/extra/context_menu.tsx
+++ b/src/renderer/components/main/extra/context_menu.tsx
@@ -189,7 +189,7 @@ class ContextMenu extends Component<{ container: IMain }, undefined> {
 
   updateAttachmentMenu = ( items ) => {
 
-    const fileName = $(this.ele).data ( 'filename' );
+    const fileName = this.ele.dataset.filename;
 
     this.attachment = this.props.container.attachment.get ( fileName );
 


### PR DESCRIPTION
Popover context menu would access the correct file once, then keep using the same value despite changing the note. (Affects version 1.4 at least). More on the issue / related bugtrack: https://github.com/notable/notable/issues/580#issuecomment-485110205
With this change, it works as intended.