### PR TITLE
Add support for dragging notes over a tag

### DIFF
--- a/src/renderer/components/main/middlebar/note.tsx
+++ b/src/renderer/components/main/middlebar/note.tsx
@@ -7,14 +7,15 @@ import Main from '@renderer/containers/main';
 
 /* NOTE */
 
-const Note = ({ note, style, title, hasAttachments, isActive, isDeleted, isFavorited, isPinned, isSelected, isMultiEditorEditing, set, toggleNote, toggleNoteRange }) => {
+const Note = ({ note, style, title, hasAttachments, isActive, isDeleted, isFavorited, isPinned, isSelected, isMultiEditorEditing, set, toggleNote, toggleNoteRange, beginNoteDragging }) => {
 
   if ( !note ) return null;
 
   const onClick = event => Svelto.Keyboard.keystroke.hasCtrlOrCmd ( event ) ? toggleNote ( note ) : ( event.shiftKey ? toggleNoteRange ( note ) : set ( note, true ) );
+  const onDragStart = () => beginNoteDragging(note)
 
   return (
-    <div style={style} className={`note ${!isMultiEditorEditing && isActive ? 'label' : 'button'} ${( isMultiEditorEditing ? isSelected : isActive ) ? 'active' : ''} list-item`} data-checksum={note.checksum} data-filepath={note.filePath} data-deleted={isDeleted} data-favorited={isFavorited} onClick={onClick}>
+    <div style={style} className={`note ${!isMultiEditorEditing && isActive ? 'label' : 'button'} ${(isMultiEditorEditing ? isSelected : isActive) ? 'active' : ''} list-item`} data-checksum={note.checksum} data-filepath={note.filePath} data-deleted={isDeleted} data-favorited={isFavorited} onClick={onClick} draggable={true} onDragStart={onDragStart}>
       <span className="title small">{title}</span>
       {!hasAttachments ? null : (
         <i className="icon xxsmall">paperclip</i>
@@ -52,7 +53,8 @@ export default connect ({
       isMultiEditorEditing: container.multiEditor.isEditing (),
       set: container.note.set,
       toggleNote: container.multiEditor.toggleNote,
-      toggleNoteRange: container.multiEditor.toggleNoteRange
+      toggleNoteRange: container.multiEditor.toggleNoteRange,
+      beginNoteDragging: container.multiEditor.beginNoteDragging
     });
 
   }

--- a/src/renderer/components/main/sidebar/tag.tsx
+++ b/src/renderer/components/main/sidebar/tag.tsx
@@ -8,7 +8,7 @@ import Main from '@renderer/containers/main';
 
 /* TAG */
 
-const Tag = ({ style, tag, level, isLeaf, isActive, set, toggleCollapse }) => {
+const Tag = ({ style, tag, level, isLeaf, isActive, set, toggleCollapse, drop }) => {
 
   if ( !tag ) return null;
 
@@ -18,10 +18,15 @@ const Tag = ({ style, tag, level, isLeaf, isActive, set, toggleCollapse }) => {
         onCollapserClick = e => {
           e.stopPropagation ();
           toggleCollapse ( path );
-        };
-
+        },
+        onDragOver = e => e.preventDefault(),
+        onDrop = e => {
+          drop(tag)
+          e.preventDefault()
+        }
+  
   return (
-    <div style={style} className={`tag ${isActive ? 'active' : ''} level-${level} button list-item`} data-tag={path} data-has-children={!isLeaf} data-collapsed={collapsed} onClick={onClick}>
+    <div style={style} className={`tag ${isActive ? 'active' : ''} level-${level} button list-item`} data-tag={path} data-has-children={!isLeaf} data-collapsed={collapsed} onClick={onClick} onDragOver={onDragOver} onDrop={onDrop}>
       {isRoot ? <i className="icon xsmall">{collapsed ? iconCollapsed || 'tag_multiple' : icon || 'tag'}</i> : null}
       {!isRoot && ( !isLeaf || collapsed ) ? <i className={`icon xsmall collapser ${collapsed ? 'rotate--90' : ''}`} onClick={onCollapserClick}>chevron_down</i> : null} {/* TODO: The collapser isn't animated because the whole list gets re-rendered */}
       {!isRoot && ( isLeaf && !collapsed ) ? <i className="icon xsmall">invisible</i> : null}
@@ -46,7 +51,8 @@ export default connect ({
       tag, style, level, isLeaf,
       isActive: container.tag.get () === tag,
       set: container.tag.set,
-      toggleCollapse: container.tag.toggleCollapse
+      toggleCollapse: container.tag.toggleCollapse,
+      drop: container.multiEditor.endDragging
     });
 
   }

--- a/src/renderer/containers/main/multi_editor.ts
+++ b/src/renderer/containers/main/multi_editor.ts
@@ -295,6 +295,17 @@ class MultiEditor extends Container<MultiEditorState, MainCTX> {
 
   }
 
+  endDragging = ( tag: TagObj ) => {
+    return this._callAll( this.ctx.note.addTag, [tag.path] )
+  }
+
+  beginNoteDragging = async ( note: NoteObj ) => {
+    const notes = this.getNotes()
+    if (_.find(notes, anNote => anNote.filePath == note.filePath) === undefined) {
+      return this.setNotes([note])
+    }
+  }
+
 }
 
 /* EXPORT */


### PR DESCRIPTION
Hi, thank you for your great app!
I just started using Notable. It was very helpful with the perfect app for my use case. I wanted to tag a lot of notes, so I needed the drag and drop functionality discussed in # 15 rather than typing.

- [x] Dragging single note over a tag adds that tag to the note
- [x] Dragging selected multiple notes over a tag adds that tag to notes

![Kapture 2019-05-04 at 0 50 30](https://user-images.githubusercontent.com/5355966/57149491-ca09a680-6e06-11e9-8051-ff620b0d39f7.gif)

I'm satisfied with the features added in this PR, but there are following problems you may concern.

- Ghost image becomes one note when dragging multiple notes
- Tags that are dragged over are not highlighted

![image](https://user-images.githubusercontent.com/5355966/57150335-fcb49e80-6e08-11e9-924d-78fdc90937f3.png)
