### PR TITLE
Add Writer mode

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -51,6 +51,9 @@ const Config = {
       barHeight: 25,
       fontSize: 14
     }
+  },
+  editor: {
+    wordWrapColumnWriterMode: 80
   }
 };
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -204,7 +204,8 @@ type WindowState = {
   focus: boolean,
   fullscreen: boolean,
   sidebar: boolean,
-  zen: boolean
+  zen: boolean,
+  writer: boolean
 };
 
 /* MAIN */

--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -345,6 +345,11 @@ class Main extends Route {
             label: 'Toggle Zen Mode',
             accelerator: 'CmdOrCtrl+Alt+Z',
             click: () => this.win.webContents.send ( 'window-zen-toggle' )
+          },
+          {
+            label: 'Toggle Writer Mode',
+            accelerator: 'CmdOrCtrl+Alt+W',
+            click: () => this.win.webContents.send ( 'window-writer-toggle' )
           }
         ]
       },

--- a/src/renderer/components/main/extra/ipc.tsx
+++ b/src/renderer/components/main/extra/ipc.tsx
@@ -26,6 +26,7 @@ class IPC extends Component<{container: IMain}, {}> {
     ipc.on ( 'window-fullscreen-set', this.__windowFullscreenSet );
     ipc.on ( 'window-sidebar-toggle', this.__windowSidebarToggle );
     ipc.on ( 'window-zen-toggle', this.__windowZenToggle );
+    ipc.on ( 'window-writer-toggle', this.__windowWriterToggle );
     ipc.on ( 'editor-split-toggle', this.__editorSplitToggle );
     ipc.on ( 'multi-editor-select-all', this.__multiEditorSelectAll );
     ipc.on ( 'multi-editor-select-invert', this.__multiEditorSelectInvert );
@@ -69,6 +70,7 @@ class IPC extends Component<{container: IMain}, {}> {
     ipc.removeListener ( 'window-fullscreen-set', this.__windowFullscreenSet );
     ipc.removeListener ( 'window-sidebar-toggle', this.__windowSidebarToggle );
     ipc.removeListener ( 'window-zen-toggle', this.__windowZenToggle );
+    ipc.removeListener ( 'window-writer-toggle', this.__windowWriterToggle );
     ipc.removeListener ( 'editor-split-toggle', this.__editorSplitToggle );
     ipc.removeListener ( 'multi-editor-select-all', this.__multiEditorSelectAll );
     ipc.removeListener ( 'multi-editor-select-invert', this.__multiEditorSelectInvert );
@@ -176,6 +178,12 @@ class IPC extends Component<{container: IMain}, {}> {
 
     this.props.container.window.toggleZen ();
 
+  }
+
+  __windowWriterToggle = () => {
+
+    this.props.container.window.toggleWriter ();
+    
   }
 
   __editorSplitToggle = () => {

--- a/src/renderer/components/main/mainbar/monaco.tsx
+++ b/src/renderer/components/main/mainbar/monaco.tsx
@@ -68,7 +68,7 @@ import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js';
 
 /* MONACO */
 
-class Monaco extends React.Component<{ filePath: string, language: string, theme: string, value: string, editorOptions?: monaco.editor.IEditorOptions, modelOptions?: monaco.editor.ITextModelUpdateOptions, className?: string, editorWillMount?: Function, editorDidMount?: Function, editorWillUnmount?: Function, editorDidUnmount?: Function, editorWillChange?: Function, onBlur?: Function, onFocus?: Function, onChange?: Function, onUpdate?: Function, onScroll?: Function, container: IMain }, {}> {
+class Monaco extends React.Component<{ filePath: string, language: string, theme: string, value: string, editorOptions?: monaco.editor.IEditorOptions, modelOptions?: monaco.editor.ITextModelUpdateOptions, className?: string, customStyle: Object, editorWillMount?: Function, editorDidMount?: Function, editorWillUnmount?: Function, editorDidUnmount?: Function, editorWillChange?: Function, onBlur?: Function, onFocus?: Function, onChange?: Function, onUpdate?: Function, onScroll?: Function, container: IMain }, {}> {
 
   /* VARIABLES */
 
@@ -117,6 +117,8 @@ class Monaco extends React.Component<{ filePath: string, language: string, theme
 
     if ( prevProps.theme !== this.props.theme ) this.updateTheme ( this.props.theme );
 
+    if ( !_.isEqual ( this.props.customStyle, prevProps.customStyle ) ) this.updateStyle ();
+
     if ( this.props.editorOptions && !_.isEqual ( prevProps.editorOptions, this.props.editorOptions ) ) this.updateEditorOptions ( this.props.editorOptions );
 
     if ( this.props.modelOptions && !_.isEqual ( prevProps.modelOptions, this.props.modelOptions ) ) this.updateModelOptions ( this.props.modelOptions );
@@ -140,6 +142,8 @@ class Monaco extends React.Component<{ filePath: string, language: string, theme
     if ( nextProps.language !== this.props.language ) this.updateLanguage ( nextProps.language );
 
     if ( nextProps.theme !== this.props.theme ) this.updateTheme ( nextProps.theme );
+
+    if ( !_.isEqual ( this.props.customStyle, nextProps.customStyle ) ) this.updateStyle ();
 
     if ( nextProps.editorOptions && !_.isEqual ( this.props.editorOptions, nextProps.editorOptions ) ) this.updateEditorOptions ( nextProps.editorOptions );
 
@@ -398,8 +402,13 @@ class Monaco extends React.Component<{ filePath: string, language: string, theme
 
   }
 
-  updateEditorOptions ( editorOptions: monaco.editor.IEditorOptions ) {
+  updateStyle () {
 
+    this.forceUpdate();
+
+  }
+
+  updateEditorOptions ( editorOptions: monaco.editor.IEditorOptions ) {
     if ( !this.editor ) return;
 
     this.editor.updateOptions ( editorOptions );
@@ -424,9 +433,9 @@ class Monaco extends React.Component<{ filePath: string, language: string, theme
 
   render () {
 
-    const {className} = this.props;
-
-    return <div ref={this.ref} className={`monaco-editor-wrapper ${className || ''}`} />;
+    const {className, customStyle} = this.props;
+    console.log("Custom style updated: ", customStyle);
+    return <div ref={this.ref} style={customStyle} className={`monaco-editor-wrapper ${className || ''}`} />;
 
   }
 

--- a/src/renderer/containers/main/window.ts
+++ b/src/renderer/containers/main/window.ts
@@ -14,7 +14,8 @@ class Window extends Container<WindowState, MainCTX> {
     focus: false,
     fullscreen: remote.getCurrentWindow ().isFullScreen (),
     sidebar: true,
-    zen: false
+    zen: false,
+    writer: false
   };
 
   /* CONSTRUCTOR */
@@ -62,6 +63,18 @@ class Window extends Container<WindowState, MainCTX> {
   toggleZen = ( zen: boolean = !this.state.zen ) => {
 
     return this.setState ({ zen });
+
+  }
+
+  isWriter = (): boolean => {
+
+    return this.state.writer;
+
+  }
+
+  toggleWriter = ( writer: boolean = !this.state.writer ) => {
+
+    return this.setState ({ writer });
 
   }
 


### PR DESCRIPTION
Hi,

I wanted to have the ability to write documents/books in a page style format, so you can see paragraphs instead of endless lines. You do have similar typewriter modes in VSCode and other IDEs that puts the editor area in the center. This mode adds a 80 columns limit on line length and resize/center the input area accordingly. Here is the result:

![writer_mode_normal](https://user-images.githubusercontent.com/5214384/61591624-0f00d600-abc9-11e9-95bb-723372ac75db.png)

Combined with Zen mode:

![writer_mode](https://user-images.githubusercontent.com/5214384/61591494-d3b1d780-abc7-11e9-850d-3f2c8e246c3d.png)

Few remarks:
- I'm not sure I did it the right way so comments are more than welcome!
- [Bug] When you are in preview mode, toggle the Writer mode and go to edit mode, I can't access the char width value yes(?) and can't compute the editor width correctly. Would need help on that.

![writer_mode_bug](https://user-images.githubusercontent.com/5214384/61591627-1627e400-abc9-11e9-922d-3bff24809fdf.png)

- [Bug] When you are in Writer mode and you toggle sidebar (hiding it), the scrollbar will show in editor even if it's not needed. Toggling Writer mode Off/On removes it.

![writer_mode_scrollbar](https://user-images.githubusercontent.com/5214384/61591682-d1507d00-abc9-11e9-800b-3f2ec3a4b93e.png)

Thanks for this tool by the way, very neat :)

