### PR TITLE
Replace nbsp with space on code block copy

### DIFF
--- a/src/renderer/components/main/extra/preview_plugins.tsx
+++ b/src/renderer/components/main/extra/preview_plugins.tsx
@@ -102,7 +102,7 @@ class PreviewPlugins extends Component<{ container: IMain }, {}> {
 
     if ( !$code.length ) return;
 
-    this.props.container.clipboard.set ( $code.text () );
+    this.props.container.clipboard.set ( $code.text ().replace( /\u00a0/g, " " ) );
 
   }
 


### PR DESCRIPTION
Code blocks render spaces as non-breaking spaces (nbsp) in order to
prevent wrapping over lines. When copied with the "Copy to Clipboard"
button, the nbsp was copied, which can not be pasted into some
applications, like the terminal, which require standard spaces.

This replaces any occurence of nbsp with a standard space character when
the copy to clipboard button is clicked.

Closes #778.