### PR TITLE
Remove tag

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -100,7 +100,8 @@ type TagObj = {
   iconCollapsed?: string,
   tags: {
     [name: string]: TagObj
-  }
+  },
+  removable: boolean
 };
 
 type TagsObj = {

--- a/src/renderer/components/main/extra/context_menu.tsx
+++ b/src/renderer/components/main/extra/context_menu.tsx
@@ -208,6 +208,7 @@ class ContextMenu extends Component<{ container: IMain }, {}> {
 
   initTagMenu = () => {
 
+    let self = this
     this._makeMenu ( '.sidebar .tag, .preview .tag', [
       {
         label: 'Collapse',
@@ -223,6 +224,13 @@ class ContextMenu extends Component<{ container: IMain }, {}> {
       {
         label: 'Copy',
         click: () => this.props.container.clipboard.set ( this.tag )
+      },
+      {
+        label: 'Remove Tag',
+        click: () => this.props.container.tag.removeFromAllNotes( this.tag ),
+        get visible() {
+          return self.props.container.tag.isRemovable( self.tag )
+        }
       }
     ], this.updateTagMenu );
 

--- a/src/renderer/containers/main/tag.ts
+++ b/src/renderer/containers/main/tag.ts
@@ -3,6 +3,7 @@
 
 import * as _ from 'lodash';
 import {Container, autosuspend} from 'overstated';
+import Dialog from 'electron-dialog';
 import Tags, {TagSpecials} from '@renderer/utils/tags';
 
 const {SEPARATOR} = Tags;
@@ -42,6 +43,30 @@ class Tag extends Container<TagState, MainCTX> {
           obj = tags.reduce ( ( acc, tag ) => acc.tags && acc.tags[tag] || {}, { tags: this.ctx.tags.get () } );
 
     return _.isEmpty ( obj ) ? undefined : obj as TagObj; //FIXME: This type casting looks wrong
+
+  }
+
+  isRemovable = (tag: string): boolean => {
+
+    const obj = this.get( tag )
+
+    return obj !== undefined && obj.removable
+  
+  }
+
+  removeFromAllNotes = (tag: string): void => {
+
+    const tagObj = this.get( tag )
+
+    if (tagObj) {
+    
+      const notes = tagObj.notes
+
+      if ( !Dialog.confirm ( `Are you sure you want to remove the tag "${tag}" from ${notes.length} notes?` ) ) return;
+      
+      notes.forEach(note => this.ctx.note.removeTag(note, tag))
+    
+    }
 
   }
 

--- a/src/renderer/containers/main/tag.ts
+++ b/src/renderer/containers/main/tag.ts
@@ -61,8 +61,10 @@ class Tag extends Container<TagState, MainCTX> {
     if (tagObj) {
     
       const notes = tagObj.notes
+      
+      let suffix = notes.length !== 1 ? 's' : ''
 
-      if ( !Dialog.confirm ( `Are you sure you want to remove the tag "${tag}" from ${notes.length} notes?` ) ) return;
+      if ( !Dialog.confirm ( `Are you sure you want to remove the tag "${tag}" from ${notes.length} note${suffix}?` ) ) return;
       
       notes.forEach(note => this.ctx.note.removeTag(note, tag))
     

--- a/src/renderer/containers/main/tags.ts
+++ b/src/renderer/containers/main/tags.ts
@@ -103,7 +103,7 @@ class Tags extends Container<TagsState, MainCTX> {
               const path = currentParts.join ( SEPARATOR ),
                     collapsed = this.ctx.tag.isCollapsed ( path )
 
-              tags[tag] = { path, name: tag, collapsed, notes: [], tags: {} };
+              tags[tag] = { path, name: tag, collapsed, notes: [], tags: {}, removable: true };
 
             }
 
@@ -147,13 +147,13 @@ class Tags extends Container<TagsState, MainCTX> {
 
     let tags: TagsObj = {};
 
-    tags[ALL] = { icon: 'note', collapsed: false, path: ALL, name: TagSpecialsNames.ALL, notes: [], tags: {} };
-    tags[FAVORITES] = { icon: 'star', collapsed: false, path: FAVORITES, name: TagSpecialsNames.FAVORITES, notes: [], tags: {} };
-    tags[NOTEBOOKS] = { icon: 'notebook', iconCollapsed: 'notebook_multiple', collapsed: false, path: NOTEBOOKS, name: TagSpecialsNames.NOTEBOOKS, notes: [], tags: {} };
-    tags[TAGS] = { collapsed: false, path: TAGS, name: TagSpecialsNames.TAGS, notes: [], tags: {} };
-    tags[TEMPLATES] = { icon: 'tag_outline', iconCollapsed: 'tag_outline_multiple', collapsed: false, path: TEMPLATES, name: TagSpecialsNames.TEMPLATES, notes: [], tags: {} };
-    tags[UNTAGGED] = { icon: 'tag_crossed', collapsed: false, path: UNTAGGED, name: TagSpecialsNames.UNTAGGED, notes: [], tags: {} };
-    tags[TRASH] = { icon: 'delete', collapsed: false, path: TRASH, name: TagSpecialsNames.TRASH, notes: [], tags: {} };
+    tags[ALL] = { icon: 'note', collapsed: false, path: ALL, name: TagSpecialsNames.ALL, notes: [], tags: {}, removable: false };
+    tags[FAVORITES] = { icon: 'star', collapsed: false, path: FAVORITES, name: TagSpecialsNames.FAVORITES, notes: [], tags: {}, removable: false  };
+    tags[NOTEBOOKS] = { icon: 'notebook', iconCollapsed: 'notebook_multiple', collapsed: false, path: NOTEBOOKS, name: TagSpecialsNames.NOTEBOOKS, notes: [], tags: {}, removable: false  };
+    tags[TAGS] = { collapsed: false, path: TAGS, name: TagSpecialsNames.TAGS, notes: [], tags: {}, removable: false  };
+    tags[TEMPLATES] = { icon: 'tag_outline', iconCollapsed: 'tag_outline_multiple', collapsed: false, path: TEMPLATES, name: TagSpecialsNames.TEMPLATES, notes: [], tags: {}, removable: false  };
+    tags[UNTAGGED] = { icon: 'tag_crossed', collapsed: false, path: UNTAGGED, name: TagSpecialsNames.UNTAGGED, notes: [], tags: {}, removable: false };
+    tags[TRASH] = { icon: 'delete', collapsed: false, path: TRASH, name: TagSpecialsNames.TRASH, notes: [], tags: {}, removable: false };
 
     Object.values ( this.ctx.notes.get () ).forEach ( note => this._toggleNote ( tags, note, true ) );
 


### PR DESCRIPTION
If you want to remove a certain tag from all notes, there's no quick shortcut. This PR adds a menu option for that.

![add_remove_tag](https://user-images.githubusercontent.com/10373500/63215490-17dcbd00-c11f-11e9-9f8e-3f6730d54208.gif)

Also, I found out this: https://github.com/notable/notable/blob/25f70631cb3e0319008ccdd3d6b404bb4874853b/src/renderer/components/main/extra/context_menu.tsx#L293-L306

Is this a hack to change the items properties dynamically? If so, you could use a `getter` on those properties, like this:

https://github.com/notable/notable/compare/master...afonsomatos:remove_tag?expand=1#diff-04c912fecf40632f03195cce92314d82R231-R233

Other thing I found tricky is the lack of ESLint. The style of the code is very unusual (lots of whitespaces). Without a linter, it's going to be difficult to maintain a coherent code style.
