### PR TITLE
Cast tag names to strings

### DIFF
--- a/src/renderer/components/main/extra/context_menu.tsx
+++ b/src/renderer/components/main/extra/context_menu.tsx
@@ -286,13 +286,13 @@ class ContextMenu extends Component<{ container: IMain }, {}> {
 
   updateNoteTagMenu = ( items: MenuItem[] ) => {
 
-    this.tag = $(this.ele).data ( 'tag' );
+    this.tag = String ( $(this.ele).data ( 'tag' ) );
 
   }
 
   updateTagMenu = ( items: MenuItem[] ) => {
 
-    this.tag = $(this.ele).data ( 'tag' );
+    this.tag = String( $(this.ele).data ( 'tag' ) );
 
     const hasChildren = this.props.container.tag.hasChildren ( this.tag ),
           isCollapsed = hasChildren && this.props.container.tag.isCollapsed ( this.tag ),

--- a/src/renderer/components/main/popovers/tag.tsx
+++ b/src/renderer/components/main/popovers/tag.tsx
@@ -13,7 +13,7 @@ const Tag = ({ tag, set, removeTag }) => {
   if ( !tag ) return null;
 
   return (
-    <div className="tag button list-item" data-tag={tag} onClick={() => set ( tag )}>
+    <div className="tag button list-item" data-tag={`"${String(tag)}"`} onClick={() => set ( tag )}>
       <span className="title small">{tag}</span>
       <i className="icon xxsmall actionable on-hover" onClick={e => { e.stopPropagation (); removeTag ( undefined, tag ); }}>close</i>
     </div>

--- a/src/renderer/components/main/sidebar/tag.tsx
+++ b/src/renderer/components/main/sidebar/tag.tsx
@@ -21,7 +21,7 @@ const Tag = ({ style, tag, level, isLeaf, isActive, set, toggleCollapse }) => {
         };
 
   return (
-    <div style={style} className={`tag ${isActive ? 'active' : ''} level-${level} button list-item`} data-tag={path} data-has-children={!isLeaf} data-collapsed={collapsed} onClick={onClick}>
+    <div style={style} className={`tag ${isActive ? 'active' : ''} level-${level} button list-item`} data-tag={`"${String(path)}"`} data-has-children={!isLeaf} data-collapsed={collapsed} onClick={onClick}>
       {isRoot ? <i className="icon xsmall">{collapsed ? iconCollapsed || 'tag_multiple' : icon || 'tag'}</i> : null}
       {!isRoot && ( !isLeaf || collapsed ) ? <i className={`icon xsmall collapser ${collapsed ? 'rotate--90' : ''}`} onClick={onCollapserClick}>chevron_down</i> : null} {/* TODO: The collapser isn't animated because the whole list gets re-rendered */}
       {!isRoot && ( isLeaf && !collapsed ) ? <i className="icon xsmall">invisible</i> : null}


### PR DESCRIPTION
Fixes #784 

`Cash.data` is used to retrieve the tag name from the selected DOM element. However, this function does not cast its return value to a string. If the attribute is "false", "null", "312" or "true", it casts them to boolean, null or number. This is not the wanted behavior for tag names.

This PR casts the "tag" attribute value to a string before assignment. And, stores tag names/paths in attributes with surrounding quotes.